### PR TITLE
Incorrect FC variable naming

### DIFF
--- a/cinder-huawei/templates/cinder_huawei_conf.xml
+++ b/cinder-huawei/templates/cinder_huawei_conf.xml
@@ -19,7 +19,7 @@
         {% if initiator_name != '' -%}
         {% set initiators = initiator_name.split(';') %}
         {% for initiator in initiators -%}
-        <Initiator HostName="{{ initiator }}" TargetPortGroup="{{ target_portgroup }}" />
+        <Initiator Name="{{ initiator }}" TargetPortGroup="{{ target_portgroup }}" />
         {% endfor %}
         {% endif %}
     </iSCSI>

--- a/cinder-huawei/templates/cinder_huawei_conf.xml
+++ b/cinder-huawei/templates/cinder_huawei_conf.xml
@@ -19,7 +19,7 @@
         {% if initiator_name != '' -%}
         {% set initiators = initiator_name.split(';') %}
         {% for initiator in initiators -%}
-        <Initiator Name="{{ initiator }}" TargetPortGroup="{{ target_portgroup }}" />
+        <Initiator HostName="{{ initiator }}" TargetPortGroup="{{ target_portgroup }}" />
         {% endfor %}
         {% endif %}
     </iSCSI>
@@ -29,7 +29,7 @@
         {% if fc_hostname != '' -%}
         {% set hostnames = fc_hostname.split(';') %}
         {% for hostname in hostnames -%}
-        <Initiator HostName="{{ hostname }}" ALUA="{{ alua }}" FAILOVERMODE="{{ failovermode }}" PATHTYPE="{{ pathtype }}"/>
+        <Initiator Name="{{ hostname }}" ALUA="{{ alua }}" FAILOVERMODE="{{ failovermode }}" PATHTYPE="{{ pathtype }}"/>
         {% endfor %}
         {% endif %}
     </FC>


### PR DESCRIPTION
According to upsteam documentation : https://docs.openstack.org/cinder/2024.1/configuration/block-storage/drivers/huawei-storage-driver.html iSCSI should use HostName and FC should use Name.
This fix has been tested in a charmed Openstack environment (jammy/caracal).