### PR TITLE
Update the test-requirements to zaza from pypi

### DIFF
--- a/cinder-huawei/test-requirements.txt
+++ b/cinder-huawei/test-requirements.txt
@@ -1,7 +1,6 @@
 # This file is managed centrally.  If you find the need to modify this as a
 # one-off, please don't.  Intead, consult #openstack-charms and ask about
 # requirements management in charms via bot-control.  Thank you.
-charm-tools>=2.4.4
 coverage>=3.6
 mock>=1.2
 flake8>=4.0.1; python_version >= '3.6'
@@ -10,7 +9,7 @@ requests>=2.18.4
 psutil
 # oslo.i18n dropped py35 support
 oslo.i18n<4.0.0
-git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+zaza==2024.*
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
 pytz    # workaround for 14.04 pip/tox
 pyudev  # for ceph-* charm unit tests (not mocked?)


### PR DESCRIPTION
Follow a similar update done on other charms
such as charm-cinder. It unblocks tox from
running any test.