### PR TITLE
Add newly mandatory field with FC backend

### DIFF
--- a/cinder-huawei/config.yaml
+++ b/cinder-huawei/config.yaml
@@ -49,13 +49,13 @@ options:
       Semicolon(;) separated list of storage pools to be used.
   luntype:
     type: string
-    default: Thin 
+    default: Thin
     description: |
-      Type of the LUNs to be created. The value can be Thick or Thin. Dorado series 
+      Type of the LUNs to be created. The value can be Thick or Thin. Dorado series
       only support Thin LUNs.
   default-targetip:
     type: string
-    default: 
+    default:
     description: |
       Default IP address of the iSCSI target that is provided for compute nodes.
   initiator-name:
@@ -75,8 +75,16 @@ options:
     default:
     description: |
       List of FC initiators host names, separated by the semicolons.
-      Use regular expression for every Nova or Cinder node's host names, 
+      Use regular expression for every Nova or Cinder node's host names,
       for example, "cinder-[0-9]" or "compute.*"
+  fc-minonlinefcinitiator:
+    type: int
+    default: 1
+    description: |
+      Configured when the protocol is FC.
+      Minimum number of available FC initiators. The value indicates the number
+      of initiators that must be online to complete volume mounting.
+      Setting it to -1 will remove this configuration entirely
   alua:
     type: int
     default: 1

--- a/cinder-huawei/src/charm.py
+++ b/cinder-huawei/src/charm.py
@@ -104,6 +104,7 @@ class CinderHuaweiCharm(CinderStoragePluginCharm):
             'initiator_name': cfg.get('initiator-name'),
             'target_portgroup': cfg.get('target-portgroup'),
             'fc_hostname': cfg.get('fc-hostname'),
+            'fc_minonlinefcinitiator': cfg.get('fc-minonlinefcinitiator'),
             'alua': cfg.get('alua'),
             'failovermode': cfg.get('failover-mode'),
             'pathtype': cfg.get('path-type')

--- a/cinder-huawei/templates/cinder_huawei_conf.xml
+++ b/cinder-huawei/templates/cinder_huawei_conf.xml
@@ -26,6 +26,9 @@
     {% endif %}
     {% if protocol == "fc" %}
     <FC>
+        {% if fc_minonlinefcinitiator > -1 -%}
+        <MinOnlineFCInitiator>{{ fc_minonlinefcinitiator }}</MinOnlineFCInitiator>
+        {% endif %}
         {% if fc_hostname != '' -%}
         {% set hostnames = fc_hostname.split(';') %}
         {% for hostname in hostnames -%}


### PR DESCRIPTION
When using Huawei Dorado backend, the driver
will fail to work on cloud nodes without the
specification of MinOnlineFCInitiator option
to indicate how many FC adapters are required
to mount a volume.