### PR TITLE
Adding config checks for Cinder Huawei

### DIFF
--- a/cinder-huawei/src/charm.py
+++ b/cinder-huawei/src/charm.py
@@ -18,10 +18,11 @@
 # import base64
 import os
 import logging
+from xml.sax.saxutils import escape
 
 from ops_openstack.plugins.classes import CinderStoragePluginCharm
 from ops.main import main
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, BlockedStatus
 from charmhelpers.core.templating import render
 from charmhelpers.core.host import mkdir
 
@@ -84,6 +85,22 @@ class CinderHuaweiCharm(CinderStoragePluginCharm):
 
     def on_config(self, event):
         config = dict(self.framework.model.config)
+
+        protocol = config.get('protocol')
+        luntype = config.get('luntype')
+
+        if protocol not in ['iscsi', 'fc']:
+            self.unit.status = BlockedStatus(
+                f"Invalid protocol: {protocol}. Must be 'iscsi' or 'fc'"
+            )
+            return
+
+        if luntype not in ['Thin', 'Thick']:
+            self.unit.status = BlockedStatus(
+                f"Invalid luntype: {luntype}. Must be 'Thin' or 'Thick'"
+            )
+            return
+
         app_name = self.framework.model.app.name
         for relation in self.framework.model.relations.get('storage-backend'):
             self.set_data(relation.data[self.unit], config, app_name)
@@ -94,11 +111,11 @@ class CinderHuaweiCharm(CinderStoragePluginCharm):
         """Returns a rendered huawer conf file"""
         huaweicontext = {
             'protocol': cfg.get('protocol'),
-            'product': cfg.get('product'),
-            'username': cfg.get('username'),
-            'password': cfg.get('password'),
-            'rest_url': cfg.get('rest-url'),
-            'storage_pool': cfg.get('storage-pool'),
+            'product': escape(str(cfg.get('product') or '')),
+            'username': escape(str(cfg.get('username') or '')),
+            'password': escape(str(cfg.get('password') or '')),
+            'rest_url': escape(str(cfg.get('rest-url') or '')),
+            'storage_pool': escape(str(cfg.get('storage-pool') or '')),
             'luntype': cfg.get('luntype'),
             'default_targetip': cfg.get('default-targetip'),
             'initiator_name': cfg.get('initiator-name'),

--- a/cinder-huawei/unit_tests/test_cinder_huawei_charm.py
+++ b/cinder-huawei/unit_tests/test_cinder_huawei_charm.py
@@ -1,5 +1,6 @@
 # Copyright 2016 Canonical Ltd
 #
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -107,3 +108,93 @@ class TestCinderHuaweiCharm(unittest.TestCase):
             conf['cinder_huawei_conf_file'],
             TEST_XML_PATH
         )
+
+    def test_xml_escaping_special_characters(self):
+        """Verify that special characters in config are escaped for XML."""
+        # Test config with characters that must be escaped in XML
+        test_config = {
+            'username': 'admin&user',
+            'password': 'Pass<word>&&&e',
+            'product': 'Storage<b>',
+            'rest-url': 'https://api.com?query=1&id=2',
+            'storage-pool': 'mystoragepool',
+        }
+
+        context = self.harness.charm.get_huawei_context(test_config)
+        # & becomes &amp; < becomes &lt; > becomes &gt;
+        self.assertEqual(context['username'], 'admin&amp;user')
+        self.assertEqual(
+            context['password'],
+            'Pass&lt;word&gt;&amp;&amp;&amp;e',
+        )
+        self.assertEqual(context['product'], 'Storage&lt;b&gt;')
+        self.assertEqual(
+            context['rest_url'],
+            'https://api.com?query=1&amp;id=2',
+        )
+
+    def test_blocked_on_invalid_protocol(self):
+        """Verify charm blocks when an unsupported protocol is provided."""
+        test_config = {
+            'protocol': 'invalid-protocol',  # Not 'iscsi' or 'fc'
+            'product': 'Dorado',
+            'username': 'myuser',
+            'password': 'mypassword',
+            'storage-pool': 'mystoragepool',
+            'rest-url': 'https://example.com:8088/deviceManager/rest/',
+            'luntype': 'Thin'
+        }
+        self.harness.update_config(test_config)
+
+        self.assertTrue(isinstance(
+            self.harness.model.unit.status,
+            BlockedStatus
+        ))
+        self.assertIn(
+            "Invalid protocol",
+            self.harness.model.unit.status.message
+        )
+
+    def test_blocked_on_invalid_luntype(self):
+        """Verify charm blocks when luntype is not Thin or Thick.
+           Particularly tricky as the storage driver doesn't
+           provide a clear message as it is case sensitive."""
+        test_config = {
+            'protocol': 'iscsi',
+            'product': 'Dorado',
+            'username': 'myuser',
+            'password': 'mypassword',
+            'storage-pool': 'mystoragepool',
+            'rest-url': 'https://example.com:8088/deviceManager/rest/',
+            'luntype': 'thin',  # Lowercase 't' should be invalid
+        }
+        self.harness.update_config(test_config)
+
+        self.assertTrue(isinstance(
+            self.harness.model.unit.status,
+            BlockedStatus
+        ))
+        self.assertIn(
+            "Invalid luntype",
+            self.harness.model.unit.status.message
+        )
+
+    @patch.object(CinderHuaweiCharm, 'create_huawei_conf')
+    def test_active_on_valid_luntype(self, mock_create_huawei_conf):
+        """Verify charm is active when luntype is set to Thin or Thick"""
+        mock_create_huawei_conf.return_value = TEST_XML_PATH
+        test_config = {
+            'protocol': 'iscsi',
+            'product': 'Dorado',
+            'username': 'myuser',
+            'password': 'mypassword',
+            'storage-pool': 'mystoragepool',
+            'rest-url': 'https://example.com:8088/deviceManager/rest/',
+            'volume-backend-name': 'huawei_dorado_iscsi',
+            'luntype': 'Thin',
+        }
+        self.harness.update_config(test_config)
+        self.assertTrue(isinstance(
+            self.harness.model.unit.status,
+            ActiveStatus
+        ))


### PR DESCRIPTION
Ensure the right config is applied for protocol
or luntype, as it is case sensitive.
Ensure to escape some config options to be
compatible with XML format, a good example being
passwords containing special characters.