### PR TITLE
Add Lun Clone Mode for Huawei Driver configuration

### DIFF
--- a/cinder-huawei/config.yaml
+++ b/cinder-huawei/config.yaml
@@ -53,6 +53,13 @@ options:
     description: |
       Type of the LUNs to be created. The value can be Thick or Thin. Dorado series
       only support Thin LUNs.
+  lun-clone-mode:
+    type: string
+    default: luncopy
+    description: |
+      Method used by the storage array when cloning LUNs. The value can be
+      'fastclone' or 'luncopy'. 'fastclone' is only supported on Dorado V6
+      and later series; other products only support 'luncopy'.
   default-targetip:
     type: string
     default:

--- a/cinder-huawei/src/charm.py
+++ b/cinder-huawei/src/charm.py
@@ -117,6 +117,7 @@ class CinderHuaweiCharm(CinderStoragePluginCharm):
             'rest_url': escape(str(cfg.get('rest-url') or '')),
             'storage_pool': escape(str(cfg.get('storage-pool') or '')),
             'luntype': cfg.get('luntype'),
+            'lun_clone_mode': cfg.get('lun-clone-mode'),
             'default_targetip': cfg.get('default-targetip'),
             'initiator_name': cfg.get('initiator-name'),
             'target_portgroup': cfg.get('target-portgroup'),

--- a/cinder-huawei/templates/cinder_huawei_conf.xml
+++ b/cinder-huawei/templates/cinder_huawei_conf.xml
@@ -9,6 +9,7 @@
     </Storage>
     <LUN>
         <LUNType>{{ luntype }}</LUNType>
+        <LUNCloneMode>{{ lun_clone_mode }}</LUNCloneMode>
         <StoragePool>{{ storage_pool }}</StoragePool>
     </LUN>
     {% if protocol == "iscsi" %}


### PR DESCRIPTION
The default driver configuration for the Huawei driver for Cinder sets the copy mode to `luncopy` by default, which when making a volume clone, it creates a block-by-block copy of the source volume.

This can make volumes take around 20-30 minutes to copy a 40G volume, for instance, for a volume backed by a Huawei SAN.

According do the [Huawei Driver documentation](https://github.com/Huawei/OpenStack_Driver/blob/master/ConfigDoc/en/OpenStack%20Cinder%20Driver%20Configuration%20Guide.pdf) we should be able to set the `LUNCopyMode` to `fastclone` to speed up volume cloning.
As per the guide, the default has been set to `luncopy`, which is the same behaviour

This is currently impacting Coriolis migrations, the source and destination platforms share the same SAN.